### PR TITLE
Fixed issue that ignored lines with multiple colons (:).

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "https://github.com/xreader/whois",
     "type": "git"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "readmeFilename": "README.md",
-  "_id": "whois-ux@0.0.2",
-  "_from": "whois-ux@0.0.x"
+  "_id": "whois-ux@0.0.3",
+  "_from": "whois-ux@0.0.2"
 }

--- a/whois.js
+++ b/whois.js
@@ -15,9 +15,9 @@ exports.whois = function (ip, callback) {
 			//console.log("whois:processing line:" + (line && line.trim()) + ' '  + (line.indexOf('%') != 0) + '' +  (line.indexOf('#') != 0));
 			if (line && line.trim() && line.indexOf('%') != 0 && line.indexOf('#') != 0){
 				var dataValuePair =  line.split(":");
-				if (dataValuePair.length == 2) {
+				if (dataValuePair.length >= 2) {
 				    var name = dataValuePair[0].trim()
-				    , value = dataValuePair[1].trim();
+				    , value = dataValuePair.slice(1).join(":");
 				    if (whoisObj[name] instanceof Array) {
     						whoisObj[name].push(value);
                     } else { 


### PR DESCRIPTION
This fixes the following bug.
**BUG**: Lines with multiple colons are ignored such as:
```
Updated Date: 2015-07-08T20:08:22Z
Creation Date: 1995-06-01T04:00:00Z
Registrar Registration Expiration Date: 2018-05-31T04:00:00Z
Domain Status: clientTransferProhibited http://www.icann.org/epp#clientTransferProhibited
```
